### PR TITLE
Dockerfile: must copy `gexp` from builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN cd /go-expanse && make gexp
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
-COPY --from=builder /go-expanse/build/bin/geth /usr/local/bin/
+COPY --from=builder /go-expanse/build/bin/gexp /usr/local/bin/
 
 EXPOSE 9656 9656 42786 42786/udp
 ENTRYPOINT ["gexp"]


### PR DESCRIPTION
Dockerfile tries to copy `geth` but should copy `gexp` instead